### PR TITLE
feat(#580): a basic implementation of js function calling from askcript

### DIFF
--- a/src/askvm/lib/resource.ts
+++ b/src/askvm/lib/resource.ts
@@ -46,4 +46,26 @@ export function resource<T, A extends any[]>(
   return new Resource(...options);
 }
 
+/**
+ * Resource factory generates the resource wrappers around all the methods which are on `whitelist` of the `module` passed. Implementation of https://github.com/CatchTheTornado/askql/issues/580 for limited JS function calls inside AskScript
+ * @param module JS object which methods will be wrapped as resource handlers
+ * @param whitelist list of strings including function/method names of the module to be wrapped out
+ */
+export function factory(
+  jsModule: any,
+  whitelist: string[]
+): Record<string, Resource<any, any>> {
+  const res: Record<string, Resource<any, any>> = {};
+  Object.keys(jsModule).forEach((k) => {
+    if (whitelist.includes(k)) {
+      res[k] = resource({
+        type: any,
+        async resolver(...args: any) {
+          return jsModule[k](...args);
+        },
+      });
+    }
+  });
+  return res;
+}
 export type Resources = Record<string, Resource<any, any>>;

--- a/src/askvm/resources/core/__tests__/factory.test.ts
+++ b/src/askvm/resources/core/__tests__/factory.test.ts
@@ -1,0 +1,48 @@
+import { runUntyped } from '../../../index';
+import { parse } from '../../../../askcode/lib';
+import { factory } from '../../../lib/resource';
+import * as core from '..';
+
+const values = {};
+const moduleToBeWrapped = {
+  wrapMe1: () => {
+    return 100;
+  },
+  wrapMe2: (arg: string) => {
+    return arg;
+  },
+  dontWrapMe: () => {
+    return 0;
+  },
+};
+const wrappedResources = factory(moduleToBeWrapped, ['wrapMe1', 'wrapMe2']);
+
+function ask(code: string) {
+  return runUntyped(
+    {
+      resources: { ...core, ...wrappedResources },
+      values,
+    },
+    parse(code)
+  );
+}
+
+describe(`factory`, function () {
+  it(`factory should wrap only whitelisted resources`, async function () {
+    await expect(
+      Promise.resolve(Object.keys(wrappedResources))
+    ).resolves.toStrictEqual(['wrapMe1', 'wrapMe2']);
+  });
+  it(`should wrap wrapMe1 js method and return 100`, async function () {
+    const expectedResult = 100;
+    await expect(ask(`ask(call(get('wrapMe1')))`)).resolves.toStrictEqual(
+      expectedResult
+    );
+  });
+  it(`should wrap wrapMe2 js method nad return arg`, async function () {
+    const expectedResult = 'arg';
+    await expect(
+      ask(`ask(call(get('wrapMe2'), 'arg'))`)
+    ).resolves.toStrictEqual(expectedResult);
+  });
+});


### PR DESCRIPTION
With this feature developers get a new helper/factory method which can be used for passing JS modules and functions to AskScript without the need of manually warping them with resources.

Usage:

```js
import { factory } from 'askql/askvm/resource';
const moduleToBeWrapped = {
  wrapMe1: () => {
    return 100;
  },
  wrapMe2: (arg: string) => {
    return arg;
  },
  dontWrapMe: () => {
    return 0;
  },
};

function ask(code: string) {
  return runUntyped(
    {
      resources: {  ...factory(moduleToBeWrapped, ['wrapMe1', 'wrapMe2'])},
      values,
    },
    parse(code)
  );
}

// now you can call the function `wrapMe1` of `moduleToBeWrapped` in AskScript
ask(`ask(call(get('wrapMe1')))

```

You can easily wrap a whole module like `lodash` by just simply:

```js
  return runUntyped(
    {
      resources: {  ...factory(lodash, ['sort'])},
      values,
    },
    parse(code)
  );
```